### PR TITLE
chore: Reorganize imports in `blendcorpus/`

### DIFF
--- a/blendcorpus/__init__.py
+++ b/blendcorpus/__init__.py
@@ -1,5 +1,11 @@
-from . import parallel_state as mpu
-from .data.gpt_dataset import build_gpt_datasets
-from .data.data_samplers import build_pretraining_data_loader
-from .data.config import get_config, set_config
-from .tokenizer import build_tokenizer
+# from blendcorpus import parallel_state as mpu
+# from blendcorpus.data.gpt_dataset import build_gpt_datasets
+# from blendcorpus.data.data_samplers import build_pretraining_data_loader
+# from blendcorpus.data.config import get_config, set_config
+# from blendcorpus.tokenizer import build_tokenizer
+
+# from . import parallel_state as mpu
+# from .data.gpt_dataset import build_gpt_datasets
+# from .data.data_samplers import build_pretraining_data_loader
+# from .data.config import get_config, set_config
+# from .tokenizer import build_tokenizer

--- a/blendcorpus/data/Makefile
+++ b/blendcorpus/data/Makefile
@@ -1,8 +1,7 @@
 CXXFLAGS += -O3 -Wall -shared -std=c++11 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell python3 -m pybind11 --includes)
 LIBNAME = helpers
-#LIBEXT = $(shell python3.10-config --extension-suffix)
-LIBEXT=.cpython-310-x86_64-linux-gnu.so
+LIBEXT=$(shell python3 --version | awk '{print  $NF}' | tr "." " " | awk '{print $1 $2}')
 
 default: $(LIBNAME)$(LIBEXT)
 

--- a/blendcorpus/data/Makefile
+++ b/blendcorpus/data/Makefile
@@ -1,7 +1,9 @@
 CXXFLAGS += -O3 -Wall -shared -std=c++11 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell python3 -m pybind11 --includes)
 LIBNAME = helpers
-LIBEXT=$(shell python3 --version | awk '{print  $NF}' | tr "." " " | awk '{print $1 $2}')
+# LIBEXT=.cpython-312-x86_64-linux-gnu.so
+# LIBEXT = $(shell python3-config --extension-suffix)
+LIBEXT = $(shell python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
 
 default: $(LIBNAME)$(LIBEXT)
 

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -79,7 +79,6 @@ class BlendableDataset(torch.utils.data.Dataset):
                 logger.info(
                     " > WARNING: could not find index map files for blendable"
                     " dataset, building indices on rank 0 ...",
-                    flush=True,
                 )
                 dataset_index, dataset_sample_index = _build_indices()
                 try:

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -11,7 +11,8 @@ import numpy as np
 import torch
 
 # from megatron import print_rank_0
-from blendcorpus import mpu
+# from blendcorpus.pa import mpu
+import blendcorpus.parallel_state as mpu
 from blendcorpus.utils import Profile, PerfTrace, get_logger
 
 log = get_logger(__name__, rank_zero_only=True)

--- a/blendcorpus/data/data_samplers.py
+++ b/blendcorpus/data/data_samplers.py
@@ -6,7 +6,7 @@ import random
 import torch
 import numpy as np
 from torch.utils.data import Dataset
-from blendcorpus import mpu
+import blendcorpus.parallel_state as mpu
 from deepspeed.runtime.dataloader import RepeatingLoader
 
 

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -10,16 +10,16 @@ import numpy as np
 import torch
 import blendcorpus.parallel_state as mpu
 from blendcorpus.utils import print_rank_0
-from .config import get_config as get_args
+from blendcorpus.data.config import get_config as get_args
 
-from . import helpers  # type:ignore
-from .blendable_dataset import BlendableDataset
-from .dataset_utils import (
+from blendcorpus.data import helpers
+from blendcorpus.data.blendable_dataset import BlendableDataset
+from blendcorpus.data.dataset_utils import (
     get_datasets_weights_and_num_samples,
     get_datasets_corpuses_weights_and_num_samples,
     get_train_valid_test_split_
 )
-from .indexed_dataset import make_dataset as make_indexed_dataset
+from blendcorpus.data.indexed_dataset import make_dataset as make_indexed_dataset
 
 from blendcorpus.utils import PerfTrace, Profile, get_logger
 

--- a/blendcorpus/utils.py
+++ b/blendcorpus/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
 """Utility functions used throughout Megatron core"""
+
 from functools import reduce
 import math
 import operator
@@ -98,6 +99,7 @@ else:
     PerfTrace = dftracer()
     DFTRACER_ENABLE = False
 
+
 def get_logger(
     name: str,
     level: Optional[str] = None,
@@ -120,6 +122,7 @@ def get_logger(
         logger.setLevel("CRITICAL")
     return logger
 
+
 def current_device_name():
     if torch.cuda.is_available():
         idx = torch.cuda.current_device()
@@ -129,6 +132,7 @@ def current_device_name():
         return torch.xpu.get_device_name(idx)
     else:
         return "cpu"
+
 
 class GlobalMemoryBuffer:
     """Global buffer to avoid dynamic memory allocations.
@@ -140,15 +144,19 @@ class GlobalMemoryBuffer:
 
     def get_tensor(self, tensor_shape, dtype, name):
         required_len = reduce(operator.mul, tensor_shape, 1)
-        if self.buffer.get((name, dtype), None) is None or \
-                self.buffer[(name, dtype)].numel() < required_len:
-            self.buffer[(name, dtype)] = \
-                torch.empty(required_len,
-                            dtype=dtype,
-                            device=current_device_name(),
-                            requires_grad=False)
+        if (
+            self.buffer.get((name, dtype), None) is None
+            or self.buffer[(name, dtype)].numel() < required_len
+        ):
+            self.buffer[(name, dtype)] = torch.empty(
+                required_len,
+                dtype=dtype,
+                device=current_device_name(),
+                requires_grad=False,
+            )
 
         return self.buffer[(name, dtype)][0:required_len].view(*tensor_shape)
+
 
 def ensure_divisibility(numerator, denominator):
     """Ensure that numerator is divisible by the denominator."""
@@ -163,69 +171,78 @@ def divide(numerator, denominator):
     ensure_divisibility(numerator, denominator)
     return numerator // denominator
 
+
 def get_attr_wrapped_model(model, attr, allow_none=True):
     """Get an attribute from a wrapped model"""
     if isinstance(model, list):
         raise RuntimeError("_get_attr_wrapped_model given a list of models")
 
     if allow_none:
+
         def condition(model, attr):
             return not hasattr(model, attr)
     else:
+
         def condition(model, attr):
             return getattr(model, attr, None) is None
 
     while condition(model, attr):
         if not hasattr(model, "module"):
-            raise RuntimeError(f"_get_attr_wrapped_model couldn't find attribute {attr}")
+            raise RuntimeError(
+                f"_get_attr_wrapped_model couldn't find attribute {attr}"
+            )
 
         model = model.module
     return getattr(model, attr)
 
 
 def _kernel_make_viewless_tensor(inp, requires_grad):
-    '''Make a viewless tensor.
+    """Make a viewless tensor.
 
     View tensors have the undesirable side-affect of retaining a reference
     to the originally-viewed tensor, even after manually setting the '.data'
     field. This method creates a new tensor that links to the old tensor's
     data, without linking the viewed tensor, referenced via the '._base'
     field.
-    '''
+    """
     out = torch.empty(
         (1,),
-        dtype = inp.dtype,
-        device = inp.device,
-        requires_grad = requires_grad,
+        dtype=inp.dtype,
+        device=inp.device,
+        requires_grad=requires_grad,
     )
     out.data = inp.data
     return out
 
+
 class MakeViewlessTensor(torch.autograd.Function):
-    '''
+    """
     Autograd function to make a viewless tensor.
 
     This function should be used in cases where the computation graph needs
     to be propagated, but we only want a viewless tensor (e.g.,
     ParallelTransformer's hidden_states). Call this function by passing
     'keep_graph = True' to 'make_viewless_tensor()'.
-    '''
+    """
+
     @staticmethod
     def forward(ctx, inp, requires_grad):
         return _kernel_make_viewless_tensor(inp, requires_grad)
+
     @staticmethod
     def backward(ctx, grad_output):
         return grad_output, None
 
+
 def make_viewless_tensor(inp, requires_grad, keep_graph):
-    '''
+    """
     Entry-point for creating viewless tensors.
 
     This method should be used, rather than calling 'MakeViewlessTensor'
     or '_kernel_make_viewless_tensor' directly. This method acts as a
     switch for determining if an autograd function or a regular method
     should be used to create the tensor.
-    '''
+    """
 
     # return tensor as-is, if not a 'view'
     if inp._base is None:
@@ -237,11 +254,12 @@ def make_viewless_tensor(inp, requires_grad, keep_graph):
     else:
         return _kernel_make_viewless_tensor(inp, requires_grad)
 
-def assert_viewless_tensor(tensor, extra_msg = None):
-    '''Assert that a tensor is not a view (i.e., its '._base' field is
-    not set).'''
+
+def assert_viewless_tensor(tensor, extra_msg=None):
+    """Assert that a tensor is not a view (i.e., its '._base' field is
+    not set)."""
     if isinstance(tensor, list):
-        [ assert_viewless_tensor(t) for t in tensor ]
+        [assert_viewless_tensor(t) for t in tensor]
         return tensor
     if not isinstance(tensor, torch.Tensor):
         return tensor
@@ -252,14 +270,20 @@ def assert_viewless_tensor(tensor, extra_msg = None):
     ) % extra_msg
     return tensor
 
+
 def safely_set_viewless_tensor_data(tensor, new_data_tensor):
-    '''Safely set tensor's '.data' field.
+    """Safely set tensor's '.data' field.
 
     Check first that the tensor is viewless (i.e., '._base' not set). If not,
     raise an exception.
-    '''
-    assert_viewless_tensor(tensor, extra_msg = "FYI, tensor._base has shape %s, and new_data_tensor has shape %s." % ("--" if tensor._base is None else tensor._base.shape, new_data_tensor.shape))
+    """
+    assert_viewless_tensor(
+        tensor,
+        extra_msg="FYI, tensor._base has shape %s, and new_data_tensor has shape %s."
+        % ("--" if tensor._base is None else tensor._base.shape, new_data_tensor.shape),
+    )
     tensor.data = new_data_tensor
+
 
 def init_method_normal(sigma):
     """Init method based on N(0, sigma)."""
@@ -278,11 +302,13 @@ def scaled_init_method_normal(sigma, num_layers):
         return torch.nn.init.normal_(tensor, mean=0.0, std=std)
 
     return init_
-import datetime
-def print_rank_0(msg):
-    if torch.distributed.is_initialized() and torch.distributed.get_rank()==0:
-        print(f" [INFO][{datetime.datetime.now()}] {msg}", flush=True)
 
+
+def print_rank_0(msg):
+    import datetime
+
+    if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+        print(f" [INFO][{datetime.datetime.now()}] {msg}", flush=True)
 
 
 def get_ltor_masks_and_position_ids(

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -8,13 +8,19 @@ start_time = time.time()
 from mpi4py import MPI
 import os
 import numpy as np
-from blendcorpus import (
-    get_config, 
-    set_config, 
-    mpu, 
-    build_gpt_datasets, 
-    build_pretraining_data_loader
-)
+import blendcorpus.parallel_state as mpu
+
+from blendcorpus.data.gpt_dataset import build_gpt_datasets
+from blendcorpus.data.data_samplers import build_pretraining_data_loader
+from blendcorpus.data.config import get_config, set_config
+
+# from blendcorpus import (
+#     get_config, 
+#     set_config, 
+#     mpu, 
+#     build_gpt_datasets, 
+#     build_pretraining_data_loader
+# )
 
 
 import argparse


### PR DESCRIPTION
## Copilot Summary

This pull request refactors import statements throughout the `blendcorpus` package to use fully qualified module paths instead of relative imports. This change improves code clarity, maintainability, and reduces ambiguity in module resolution. The updates affect several files related to dataset construction, samplers, and configuration.

### Refactoring of import statements

**General import path updates:**

* Updated all relative imports in `blendcorpus/data/gpt_dataset.py` to use fully qualified paths, including imports for `helpers`, `BlendableDataset`, `dataset_utils`, and `indexed_dataset`.
* Changed the import of `mpu` in `blendcorpus/data/blendable_dataset.py` and `blendcorpus/data/data_samplers.py` to use `blendcorpus.parallel_state` instead of a relative import. [[1]](diffhunk://#diff-9e379b8022b28018e60dade9795a2f2fc36212bd4bb6998581623364622d92aeL14-R15) [[2]](diffhunk://#diff-99d26d97f8c7ab1bfecaa6cede510f0e4a564303671d018e8bf9ad61b464a2bfL9-R9)

**Initialization module changes:**

* Commented out all imports in `blendcorpus/__init__.py`, including both relative and absolute forms, likely in preparation for further initialization logic or to avoid side effects during module import.