### PR TITLE
fix: Add barrier before loading indices and fix np.save scoping bug

### DIFF
--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -68,6 +68,13 @@ class BlendableDataset(torch.utils.data.Dataset):
         self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
         if data_cache_path:
             desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
+            # Broadcast hash from rank 0 so all ranks use the same file paths.
+            # Different ranks may have different desc strings (due to round-robin
+            # dataset building), producing different hashes.
+            if torch.distributed.is_initialized():
+                hash_list = [desc_hash]
+                torch.distributed.broadcast_object_list(hash_list, src=0)
+                desc_hash = hash_list[0]
             desc_path = os.path.join(data_cache_path, desc_hash + ".dsc")
             index_path = os.path.join(data_cache_path, desc_hash + "_index.npy")
             sample_index_path = os.path.join(

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -126,18 +126,22 @@ class BlendableDataset(torch.utils.data.Dataset):
             torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
 
-            start_time = time.perf_counter()
-            logger.info(f"> loading blendable dataset index: {index_path}")
-            self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode="r")
-            assert self.dataset_index.size == self.size
-            logger.info(f"> loading blendable dataset sample index: {sample_index_path}")
-            self.dataset_sample_index = np.load(
-                sample_index_path, allow_pickle=True, mmap_mode="r"
-            )
-            assert self.dataset_sample_index.size == self.size
-            logger.info(
-                f"> finished loading in {time.perf_counter() - start_time} seconds"
-            )
+            if torch.distributed.get_rank() != 0 or cache_hit:
+                # Non-rank-0 ranks load from files that rank 0 just wrote.
+                # Rank 0 with a cache hit also needs to load (it skipped building).
+                start_time = time.perf_counter()
+                logger.info(f"> loading blendable dataset index: {index_path}")
+                self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode="r")
+                assert self.dataset_index.size == self.size
+                logger.info(f"> loading blendable dataset sample index: {sample_index_path}")
+                self.dataset_sample_index = np.load(
+                    sample_index_path, allow_pickle=True, mmap_mode="r"
+                )
+                assert self.dataset_sample_index.size == self.size
+                logger.info(
+                    f"> finished loading in {time.perf_counter() - start_time} seconds"
+                )
+            # else: rank 0 already set self.dataset_index/sample_index above
         else:
             self.dataset_index, self.dataset_sample_index = _build_indices()
 

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import os
+import pickle
 import time
 
 import ezpz
@@ -130,7 +131,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                 for attempt in range(max_retries):
                     try:
                         return np.load(path, allow_pickle=True, mmap_mode="r")
-                    except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+                    except (EOFError, ValueError, FileNotFoundError, OSError, pickle.UnpicklingError) as e:
                         if attempt < max_retries - 1:
                             logger.warning(
                                 f" > retry {attempt + 1}/{max_retries} loading "

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -123,9 +123,9 @@ class BlendableDataset(torch.utils.data.Dataset):
             #         torch.distributed.get_world_size(group=mpu.get_sequence_parallel_group())):
             #     logger.info("Data index creation unsuccessful, exiting.")
             #     exit()
-            torch.distributed.barrier(group=mpu.get_data_parallel_group())
-            torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-            torch.distributed.barrier(group=mpu.get_data_parallel_group())
+            # Global barrier so that ALL ranks (including those in different
+            # TP groups) wait for rank 0 to finish writing cache files.
+            torch.distributed.barrier()
 
             def _load_with_retry(path, label, max_retries=30, delay=2.0):
                 for attempt in range(max_retries):

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -66,38 +66,79 @@ class BlendableDataset(torch.utils.data.Dataset):
         self.desc = desc
         self.dataset_index = np.zeros(self.size, dtype=np.int64)
         self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
-        # Build blending indices on rank 0 and broadcast to all ranks.
-        # Previous approach used filesystem caching, but Lustre metadata
-        # propagation delays cause FileNotFoundError on multi-node runs.
-        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-        if rank == 0:
-            logger.info("> building blendable dataset indices on rank 0 ...")
-            self.dataset_index, self.dataset_sample_index = _build_indices()
-            # Also save to cache for future single-rank reuse
-            if data_cache_path:
+        if data_cache_path:
+            desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
+            desc_path = os.path.join(data_cache_path, desc_hash + ".dsc")
+            index_path = os.path.join(data_cache_path, desc_hash + "_index.npy")
+            sample_index_path = os.path.join(
+                data_cache_path, desc_hash + "_sample_index.npy"
+            )
+            cache_hit = os.path.isfile(index_path) and os.path.isfile(sample_index_path)
+            cache_success = True
+            if torch.distributed.get_rank() == 0 and not cache_hit:
+                logger.info(
+                    " > WARNING: could not find index map files for blendable"
+                    " dataset, building indices on rank 0 ...",
+                )
+                dataset_index, dataset_sample_index = _build_indices()
                 try:
-                    stable_desc = f"Blendable dataset\nWeights: {weights}\nSize: {size}\n"
-                    desc_hash = hashlib.md5(stable_desc.encode("utf-8")).hexdigest()
-                    os.makedirs(data_cache_path, exist_ok=True)
-                    np.save(os.path.join(data_cache_path, desc_hash + "_index.npy"),
-                            self.dataset_index, allow_pickle=True)
-                    np.save(os.path.join(data_cache_path, desc_hash + "_sample_index.npy"),
-                            self.dataset_sample_index, allow_pickle=True)
-                    logger.info(f"> saved blendable index cache to {data_cache_path}")
+                    logger.debug(" > saving index map files")
+                    start_time = time.perf_counter()
+                    os.makedirs(os.path.dirname(index_path), exist_ok=True)
+                    with open(desc_path, "wt") as fd:
+                        fd.write(desc)
+                        np.save(index_path, dataset_index, allow_pickle=True)
+                        np.save(
+                            sample_index_path, dataset_sample_index, allow_pickle=True
+                        )
+                    logger.info(
+                        f" > finished saving index map files in {time.perf_counter() - start_time} seconds"
+                    )
                 except OSError:
-                    logger.warning(f"> failed to save blendable index cache to {data_cache_path}")
+                    logger.info(
+                        " ".join(
+                            [
+                                "There was an error trying to create the data",
+                                f"cache directory ({data_cache_path})",
+                                "or a file in it. This is set with the",
+                                "--data-cache-path argument. Please ensure you",
+                                "have write access to this directory or specify one",
+                                "that you do have write access to.",
+                            ]
+                        )
+                    )
+                    cache_success = False
+                self.dataset_index = dataset_index
+                self.dataset_sample_index = dataset_sample_index
+            # XXX:
+            # I don't think the following piece of code is necessary any more;
+            # I commented them out now
+            # counts = get_accelerator().LongTensor([cache_success])
+            # torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
+            # torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+            # if counts[0].item() != (
+            #         torch.distributed.get_world_size() //
+            #         torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()) //
+            #         torch.distributed.get_world_size(group=mpu.get_sequence_parallel_group())):
+            #     logger.info("Data index creation unsuccessful, exiting.")
+            #     exit()
+            torch.distributed.barrier(group=mpu.get_data_parallel_group())
+            torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
+            torch.distributed.barrier(group=mpu.get_data_parallel_group())
 
-        # Broadcast indices from rank 0 to all ranks via torch.distributed
-        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
-            idx_tensor = torch.from_numpy(self.dataset_index).long()
-            sample_tensor = torch.from_numpy(self.dataset_sample_index).long()
-            torch.distributed.broadcast(idx_tensor, src=0)
-            torch.distributed.broadcast(sample_tensor, src=0)
-            if rank != 0:
-                self.dataset_index = idx_tensor.numpy()
-                self.dataset_sample_index = sample_tensor.numpy()
-            logger.info(f"> rank {rank}: blendable indices ready (broadcast)")
-        elif not torch.distributed.is_initialized():
+            start_time = time.perf_counter()
+            logger.info(f"> loading blendable dataset index: {index_path}")
+            self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode="r")
+            assert self.dataset_index.size == self.size
+            logger.info(f"> loading blendable dataset sample index: {sample_index_path}")
+            self.dataset_sample_index = np.load(
+                sample_index_path, allow_pickle=True, mmap_mode="r"
+            )
+            assert self.dataset_sample_index.size == self.size
+            logger.info(
+                f"> finished loading in {time.perf_counter() - start_time} seconds"
+            )
+        else:
             self.dataset_index, self.dataset_sample_index = _build_indices()
 
         # Check size

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -87,10 +87,10 @@ class BlendableDataset(torch.utils.data.Dataset):
                     os.makedirs(os.path.dirname(index_path), exist_ok=True)
                     with open(desc_path, "wt") as fd:
                         fd.write(desc)
-                        np.save(index_path, dataset_index, allow_pickle=True)
-                        np.save(
-                            sample_index_path, dataset_sample_index, allow_pickle=True
-                        )
+                    np.save(index_path, dataset_index, allow_pickle=True)
+                    np.save(
+                        sample_index_path, dataset_sample_index, allow_pickle=True
+                    )
                     logger.info(
                         f" > finished saving index map files in {time.perf_counter() - start_time} seconds"
                     )

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -67,14 +67,11 @@ class BlendableDataset(torch.utils.data.Dataset):
         self.dataset_index = np.zeros(self.size, dtype=np.int64)
         self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
         if data_cache_path:
-            desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
-            # Broadcast hash from rank 0 so all ranks use the same file paths.
-            # Different ranks may have different desc strings (due to round-robin
-            # dataset building), producing different hashes.
-            if torch.distributed.is_initialized():
-                hash_list = [desc_hash]
-                torch.distributed.broadcast_object_list(hash_list, src=0)
-                desc_hash = hash_list[0]
+            # Use a rank-independent hash: weights and size are the same on
+            # all ranks, but dataset.desc can differ due to round-robin
+            # building. Use only the deterministic fields for the hash.
+            stable_desc = f"Blendable dataset\nWeights: {weights}\nSize: {size}\n"
+            desc_hash = hashlib.md5(stable_desc.encode("utf-8")).hexdigest()
             desc_path = os.path.join(data_cache_path, desc_hash + ".dsc")
             index_path = os.path.join(data_cache_path, desc_hash + "_index.npy")
             sample_index_path = os.path.join(

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -126,14 +126,26 @@ class BlendableDataset(torch.utils.data.Dataset):
             torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
 
+            def _load_with_retry(path, label, max_retries=30, delay=2.0):
+                for attempt in range(max_retries):
+                    try:
+                        return np.load(path, allow_pickle=True, mmap_mode="r")
+                    except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+                        if attempt < max_retries - 1:
+                            logger.warning(
+                                f" > retry {attempt + 1}/{max_retries} loading "
+                                f"{label} from {path}: {e}"
+                            )
+                            time.sleep(delay)
+                        else:
+                            raise
+
             start_time = time.perf_counter()
             logger.info(f"> loading blendable dataset index: {index_path}")
-            self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode="r")
+            self.dataset_index = _load_with_retry(index_path, "blendable-index")
             assert self.dataset_index.size == self.size
             logger.info(f"> loading blendable dataset sample index: {sample_index_path}")
-            self.dataset_sample_index = np.load(
-                sample_index_path, allow_pickle=True, mmap_mode="r"
-            )
+            self.dataset_sample_index = _load_with_retry(sample_index_path, "blendable-sample-index")
             assert self.dataset_sample_index.size == self.size
             logger.info(
                 f"> finished loading in {time.perf_counter() - start_time} seconds"

--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -66,87 +66,38 @@ class BlendableDataset(torch.utils.data.Dataset):
         self.desc = desc
         self.dataset_index = np.zeros(self.size, dtype=np.int64)
         self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
-        if data_cache_path:
-            # Use a rank-independent hash: weights and size are the same on
-            # all ranks, but dataset.desc can differ due to round-robin
-            # building. Use only the deterministic fields for the hash.
-            stable_desc = f"Blendable dataset\nWeights: {weights}\nSize: {size}\n"
-            desc_hash = hashlib.md5(stable_desc.encode("utf-8")).hexdigest()
-            desc_path = os.path.join(data_cache_path, desc_hash + ".dsc")
-            index_path = os.path.join(data_cache_path, desc_hash + "_index.npy")
-            sample_index_path = os.path.join(
-                data_cache_path, desc_hash + "_sample_index.npy"
-            )
-            cache_hit = os.path.isfile(index_path) and os.path.isfile(sample_index_path)
-            cache_success = True
-            if torch.distributed.get_rank() == 0 and not cache_hit:
-                logger.info(
-                    " > WARNING: could not find index map files for blendable"
-                    " dataset, building indices on rank 0 ...",
-                )
-                dataset_index, dataset_sample_index = _build_indices()
+        # Build blending indices on rank 0 and broadcast to all ranks.
+        # Previous approach used filesystem caching, but Lustre metadata
+        # propagation delays cause FileNotFoundError on multi-node runs.
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        if rank == 0:
+            logger.info("> building blendable dataset indices on rank 0 ...")
+            self.dataset_index, self.dataset_sample_index = _build_indices()
+            # Also save to cache for future single-rank reuse
+            if data_cache_path:
                 try:
-                    logger.debug(" > saving index map files")
-                    start_time = time.perf_counter()
-                    os.makedirs(os.path.dirname(index_path), exist_ok=True)
-                    with open(desc_path, "wt") as fd:
-                        fd.write(desc)
-                    np.save(index_path, dataset_index, allow_pickle=True)
-                    np.save(
-                        sample_index_path, dataset_sample_index, allow_pickle=True
-                    )
-                    logger.info(
-                        f" > finished saving index map files in {time.perf_counter() - start_time} seconds"
-                    )
+                    stable_desc = f"Blendable dataset\nWeights: {weights}\nSize: {size}\n"
+                    desc_hash = hashlib.md5(stable_desc.encode("utf-8")).hexdigest()
+                    os.makedirs(data_cache_path, exist_ok=True)
+                    np.save(os.path.join(data_cache_path, desc_hash + "_index.npy"),
+                            self.dataset_index, allow_pickle=True)
+                    np.save(os.path.join(data_cache_path, desc_hash + "_sample_index.npy"),
+                            self.dataset_sample_index, allow_pickle=True)
+                    logger.info(f"> saved blendable index cache to {data_cache_path}")
                 except OSError:
-                    logger.info(
-                        " ".join(
-                            [
-                                "There was an error trying to create the data",
-                                f"cache directory ({data_cache_path})",
-                                "or a file in it. This is set with the",
-                                "--data-cache-path argument. Please ensure you",
-                                "have write access to this directory or specify one",
-                                "that you do have write access to.",
-                            ]
-                        )
-                    )
-                    cache_success = False
-                self.dataset_index = dataset_index
-                self.dataset_sample_index = dataset_sample_index
-            # XXX:
-            # I don't think the following piece of code is necessary any more;
-            # I commented them out now
-            # counts = get_accelerator().LongTensor([cache_success])
-            # torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-            # torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
-            # if counts[0].item() != (
-            #         torch.distributed.get_world_size() //
-            #         torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()) //
-            #         torch.distributed.get_world_size(group=mpu.get_sequence_parallel_group())):
-            #     logger.info("Data index creation unsuccessful, exiting.")
-            #     exit()
-            torch.distributed.barrier(group=mpu.get_data_parallel_group())
-            torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-            torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                    logger.warning(f"> failed to save blendable index cache to {data_cache_path}")
 
-            if torch.distributed.get_rank() != 0 or cache_hit:
-                # Non-rank-0 ranks load from files that rank 0 just wrote.
-                # Rank 0 with a cache hit also needs to load (it skipped building).
-                start_time = time.perf_counter()
-                logger.info(f"> loading blendable dataset index: {index_path}")
-                self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode="r")
-                assert self.dataset_index.size == self.size
-                logger.info(f"> loading blendable dataset sample index: {sample_index_path}")
-                self.dataset_sample_index = np.load(
-                    sample_index_path, allow_pickle=True, mmap_mode="r"
-                )
-                assert self.dataset_sample_index.size == self.size
-                logger.info(
-                    f"> finished loading in {time.perf_counter() - start_time} seconds"
-                )
-            # else: rank 0 already set self.dataset_index/sample_index above
-        else:
+        # Broadcast indices from rank 0 to all ranks via torch.distributed
+        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+            idx_tensor = torch.from_numpy(self.dataset_index).long()
+            sample_tensor = torch.from_numpy(self.dataset_sample_index).long()
+            torch.distributed.broadcast(idx_tensor, src=0)
+            torch.distributed.broadcast(sample_tensor, src=0)
+            if rank != 0:
+                self.dataset_index = idx_tensor.numpy()
+                self.dataset_sample_index = sample_tensor.numpy()
+            logger.info(f"> rank {rank}: blendable indices ready (broadcast)")
+        elif not torch.distributed.is_initialized():
             self.dataset_index, self.dataset_sample_index = _build_indices()
 
         # Check size

--- a/blendcorpus/data/data_samplers.py
+++ b/blendcorpus/data/data_samplers.py
@@ -38,11 +38,12 @@ def build_pretraining_data_loader(dataset, consumed_samples, config):
                 config.dataloader_type))
 
     # Torch dataloader.
+    pin_memory = getattr(config, "pin_memory", torch.cuda.is_available())
     loader = torch.utils.data.DataLoader(
         dataset,
         batch_sampler=batch_sampler,
         num_workers=config.num_workers,
-        pin_memory=True,
+        pin_memory=pin_memory,
         multiprocessing_context=(
             config.multiprocessing_context if config.num_workers > 0
             else None

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -256,9 +256,10 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                         cache_success = False
                     self.dataset_index = dataset_index
                     self.dataset_sample_index = dataset_sample_index
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                # Global barrier so that ALL ranks (including those in different
+                # TP groups) wait for rank 0 to finish writing cache files.
+                torch.distributed.barrier()
+
                 def _load_with_retry(path, label, max_retries=30, delay=2.0):
                     for attempt in range(max_retries):
                         try:
@@ -468,9 +469,9 @@ def build_train_valid_test_datasets(
         logger.debug(
             f" >>> Rank 0 - finished building datasets in {time.time() - start_time} seconds"
         )
-        torch.distributed.barrier(group=mpu.get_data_parallel_group())
-        torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-        torch.distributed.barrier(group=mpu.get_data_parallel_group())
+        # Global barrier so that ALL ranks (including those in different
+        # TP groups) wait for dataset building to complete.
+        torch.distributed.barrier()
         logger.debug(
             f" >>> Finished building datasets (all ranks) in distributed way in {time.time() - start_time} seconds"
         )

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -198,47 +198,85 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                 return _build_indices_concat()
 
         def _cache_indices():
-            corpus_name = self.dataset_builders[0].corpus
+            desc = self.dataset_builders[0].corpus
+            desc += (
+                f"\n {self.num_samples} "
+                f"+ blend_sample_in_corpus: {args.blend_sample_in_corpus}"
+                f"+ shuffle_sample_in_corpus: {args.shuffle_sample_in_corpus}"
+            )
             self.dataset_index = np.zeros(self.num_samples, dtype=np.int64)
             self.dataset_sample_index = np.zeros(self.num_samples, dtype=np.int64)
-
-            # Build on rank 0, broadcast to all ranks via torch.distributed.
-            # Filesystem caching is unreliable on parallel filesystems (Lustre).
-            rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-            if rank == 0:
-                logger.info(f"> building {corpus_name} corpus indices on rank 0 ...")
-                self.dataset_index, self.dataset_sample_index = _build_indices()
-                # Save cache for future single-rank reuse
-                if args.data_cache_path:
+            if args.data_cache_path:
+                desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
+                desc_path = os.path.join(args.data_cache_path, desc_hash + ".dsc")
+                index_path = os.path.join(
+                    args.data_cache_path, desc_hash + "_index.npy"
+                )
+                sample_index_path = os.path.join(
+                    args.data_cache_path, desc_hash + "_sample_index.npy"
+                )
+                cache_hit = os.path.isfile(index_path) and os.path.isfile(
+                    sample_index_path
+                )
+                cache_success = True
+                if torch.distributed.get_rank() == 0 and not cache_hit:
+                    print(
+                        " > WARNING: could not find index map files for blendable"
+                        " dataset, building indices on rank 0 ...",
+                        flush=True,
+                    )
+                    dataset_index, dataset_sample_index = _build_indices()
                     try:
-                        desc = corpus_name + (
-                            f"\n {self.num_samples} "
-                            f"+ blend_sample_in_corpus: {args.blend_sample_in_corpus}"
-                            f"+ shuffle_sample_in_corpus: {args.shuffle_sample_in_corpus}"
-                        )
-                        desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
-                        os.makedirs(args.data_cache_path, exist_ok=True)
-                        np.save(os.path.join(args.data_cache_path, desc_hash + "_index.npy"),
-                                self.dataset_index, allow_pickle=True)
-                        np.save(os.path.join(args.data_cache_path, desc_hash + "_sample_index.npy"),
-                                self.dataset_sample_index, allow_pickle=True)
-                        logger.info(
-                            f" > finished saving {corpus_name} corpus index map files"
-                        )
+                        logger.debug(" > saving index map files")
+                        start_time = time.perf_counter()
+                        os.makedirs(os.path.dirname(index_path), exist_ok=True)
+                        with open(desc_path, "wt") as fd:
+                            fd.write(desc)
+                            np.save(index_path, dataset_index, allow_pickle=True)
+                            np.save(
+                                sample_index_path,
+                                dataset_sample_index,
+                                allow_pickle=True,
+                            )
+                            logger.info(
+                                f" > finished saving {self.dataset_builders[0].corpus} corpus index map files in {time.perf_counter() - start_time} seconds"
+                            )
                     except OSError:
-                        logger.warning(f"> failed to save {corpus_name} corpus index cache")
-
-            # Broadcast from rank 0 to all ranks
-            if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
-                idx_tensor = torch.from_numpy(self.dataset_index).long()
-                sample_tensor = torch.from_numpy(self.dataset_sample_index).long()
-                torch.distributed.broadcast(idx_tensor, src=0)
-                torch.distributed.broadcast(sample_tensor, src=0)
-                if rank != 0:
-                    self.dataset_index = idx_tensor.numpy()
-                    self.dataset_sample_index = sample_tensor.numpy()
-                logger.info(f"> rank {rank}: {corpus_name} corpus indices ready (broadcast)")
-            elif not torch.distributed.is_initialized():
+                        print(
+                            f"There was an error trying to create the data cache directory ({args.data_cache_path})"
+                        )
+                        print(
+                            "or a file in it. This is set with the --data-cache-path argument. Please"
+                        )
+                        print(
+                            "ensure you have write access to this directory or specify one that you do have"
+                        )
+                        print("write access to.")
+                        cache_success = False
+                    self.dataset_index = dataset_index
+                    self.dataset_sample_index = dataset_sample_index
+                torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
+                torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                start_time = time.perf_counter()
+                logger.info(
+                    f"> loading {self.dataset_builders[0].corpus} corpus dataset index: {index_path}"
+                )
+                self.dataset_index = np.load(
+                    index_path, allow_pickle=True, mmap_mode="r"
+                )
+                assert self.dataset_index.size == self.num_samples
+                logger.info(
+                    f"> loading {self.dataset_builders[0].corpus} corpus dataset sample index: {sample_index_path}"
+                )
+                self.dataset_sample_index = np.load(
+                    sample_index_path, allow_pickle=True, mmap_mode="r"
+                )
+                assert self.dataset_sample_index.size == self.num_samples
+                logger.info(
+                    f"> finished loading in {time.perf_counter() - start_time} seconds"
+                )
+            else:
                 self.dataset_index, self.dataset_sample_index = _build_indices()
 
         _cache_indices()
@@ -1082,25 +1120,20 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
-    if not build_indices:
-        # This rank didn't build — load from files written by another rank.
-        # The caller's barrier (in build_train_valid_test_datasets) ensures
-        # these files are fully written before we reach here.
-        start_time = time.time()
-        logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
-        doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
+    # Load mappings.
+    start_time = time.time()
+    logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
+    doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
 
-        logger.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
-        sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
+    logger.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
+    sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
 
-        logger.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
-        shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
+    logger.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
+    shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
 
-        logger.debug(
-            "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)
-        )
-    # else: doc_idx, sample_idx, shuffle_idx already in memory from building above
-
+    logger.debug(
+        "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)
+    )
     logger.debug("    total number of samples: {}".format(sample_idx.shape[0]))
     logger.debug("    total number of epochs: {}".format(num_epochs))
 

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -1120,6 +1120,13 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
+    # Barrier to ensure all ranks have finished writing index files
+    # before any rank tries to load them. Critical on parallel filesystems
+    # (e.g. Lustre) where writes from one node may not be immediately
+    # visible to other nodes.
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
     # Load mappings.
     start_time = time.time()
     logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -1120,27 +1120,25 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
-    # Barrier to ensure all ranks have finished writing index files
-    # before any rank tries to load them. Critical on parallel filesystems
-    # (e.g. Lustre) where writes from one node may not be immediately
-    # visible to other nodes.
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+    if not build_indices:
+        # This rank didn't build — load from files written by another rank.
+        # The caller's barrier (in build_train_valid_test_datasets) ensures
+        # these files are fully written before we reach here.
+        start_time = time.time()
+        logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
+        doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
 
-    # Load mappings.
-    start_time = time.time()
-    logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
-    doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
+        logger.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
+        sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
 
-    logger.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
-    sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
+        logger.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
+        shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
 
-    logger.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
-    shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
+        logger.debug(
+            "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)
+        )
+    # else: doc_idx, sample_idx, shuffle_idx already in memory from building above
 
-    logger.debug(
-        "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)
-    )
     logger.debug("    total number of samples: {}".format(sample_idx.shape[0]))
     logger.debug("    total number of epochs: {}".format(num_epochs))
 

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -258,19 +258,32 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
                 torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                def _load_with_retry(path, label, max_retries=30, delay=2.0):
+                    for attempt in range(max_retries):
+                        try:
+                            return np.load(path, allow_pickle=True, mmap_mode="r")
+                        except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+                            if attempt < max_retries - 1:
+                                logger.warning(
+                                    f" > retry {attempt + 1}/{max_retries} loading "
+                                    f"{label} from {path}: {e}"
+                                )
+                                time.sleep(delay)
+                            else:
+                                raise
+
+                corpus_name = self.dataset_builders[0].corpus
                 start_time = time.perf_counter()
                 logger.info(
-                    f"> loading {self.dataset_builders[0].corpus} corpus dataset index: {index_path}"
+                    f"> loading {corpus_name} corpus dataset index: {index_path}"
                 )
-                self.dataset_index = np.load(
-                    index_path, allow_pickle=True, mmap_mode="r"
-                )
+                self.dataset_index = _load_with_retry(index_path, f"{corpus_name}-index")
                 assert self.dataset_index.size == self.num_samples
                 logger.info(
-                    f"> loading {self.dataset_builders[0].corpus} corpus dataset sample index: {sample_index_path}"
+                    f"> loading {corpus_name} corpus dataset sample index: {sample_index_path}"
                 )
-                self.dataset_sample_index = np.load(
-                    sample_index_path, allow_pickle=True, mmap_mode="r"
+                self.dataset_sample_index = _load_with_retry(
+                    sample_index_path, f"{corpus_name}-sample-index"
                 )
                 assert self.dataset_sample_index.size == self.num_samples
                 logger.info(
@@ -1120,16 +1133,32 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
-    # Load mappings.
+    # Load mappings with retry — on parallel filesystems (Lustre), files
+    # written by one rank may not be immediately visible/complete on other
+    # nodes even after a barrier.
+    def _load_with_retry(path, label, max_retries=30, delay=2.0):
+        for attempt in range(max_retries):
+            try:
+                return np.load(path, allow_pickle=True, mmap_mode="r")
+            except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f" > retry {attempt + 1}/{max_retries} loading {label} "
+                        f"from {path}: {e}"
+                    )
+                    time.sleep(delay)
+                else:
+                    raise
+
     start_time = time.time()
     logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
-    doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
+    doc_idx = _load_with_retry(idx_path["doc"], "doc-idx")
 
     logger.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
-    sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
+    sample_idx = _load_with_retry(idx_path["sample"], "sample-idx")
 
     logger.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
-    shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
+    shuffle_idx = _load_with_retry(idx_path["shuffle"], "shuffle-idx")
 
     logger.debug(
         "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import os
+import pickle
 import time
 
 import ezpz
@@ -262,7 +263,7 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                     for attempt in range(max_retries):
                         try:
                             return np.load(path, allow_pickle=True, mmap_mode="r")
-                        except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+                        except (EOFError, ValueError, FileNotFoundError, OSError, pickle.UnpicklingError) as e:
                             if attempt < max_retries - 1:
                                 logger.warning(
                                     f" > retry {attempt + 1}/{max_retries} loading "
@@ -1140,7 +1141,7 @@ def _build_index_mappings(
         for attempt in range(max_retries):
             try:
                 return np.load(path, allow_pickle=True, mmap_mode="r")
-            except (EOFError, ValueError, FileNotFoundError, OSError) as e:
+            except (EOFError, ValueError, FileNotFoundError, OSError, pickle.UnpicklingError) as e:
                 if attempt < max_retries - 1:
                     logger.warning(
                         f" > retry {attempt + 1}/{max_retries} loading {label} "

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -198,90 +198,47 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                 return _build_indices_concat()
 
         def _cache_indices():
-            desc = self.dataset_builders[0].corpus
-            desc += (
-                f"\n {self.num_samples} "
-                f"+ blend_sample_in_corpus: {args.blend_sample_in_corpus}"
-                f"+ shuffle_sample_in_corpus: {args.shuffle_sample_in_corpus}"
-            )
+            corpus_name = self.dataset_builders[0].corpus
             self.dataset_index = np.zeros(self.num_samples, dtype=np.int64)
             self.dataset_sample_index = np.zeros(self.num_samples, dtype=np.int64)
-            if args.data_cache_path:
-                # desc is rank-independent (corpus name, num_samples, config flags)
-                desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
-                desc_path = os.path.join(args.data_cache_path, desc_hash + ".dsc")
-                index_path = os.path.join(
-                    args.data_cache_path, desc_hash + "_index.npy"
-                )
-                sample_index_path = os.path.join(
-                    args.data_cache_path, desc_hash + "_sample_index.npy"
-                )
-                cache_hit = os.path.isfile(index_path) and os.path.isfile(
-                    sample_index_path
-                )
-                cache_success = True
-                if torch.distributed.get_rank() == 0 and not cache_hit:
-                    print(
-                        " > WARNING: could not find index map files for blendable"
-                        " dataset, building indices on rank 0 ...",
-                        flush=True,
-                    )
-                    dataset_index, dataset_sample_index = _build_indices()
+
+            # Build on rank 0, broadcast to all ranks via torch.distributed.
+            # Filesystem caching is unreliable on parallel filesystems (Lustre).
+            rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+            if rank == 0:
+                logger.info(f"> building {corpus_name} corpus indices on rank 0 ...")
+                self.dataset_index, self.dataset_sample_index = _build_indices()
+                # Save cache for future single-rank reuse
+                if args.data_cache_path:
                     try:
-                        logger.debug(" > saving index map files")
-                        start_time = time.perf_counter()
-                        os.makedirs(os.path.dirname(index_path), exist_ok=True)
-                        with open(desc_path, "wt") as fd:
-                            fd.write(desc)
-                        np.save(index_path, dataset_index, allow_pickle=True)
-                        np.save(
-                            sample_index_path,
-                            dataset_sample_index,
-                            allow_pickle=True,
+                        desc = corpus_name + (
+                            f"\n {self.num_samples} "
+                            f"+ blend_sample_in_corpus: {args.blend_sample_in_corpus}"
+                            f"+ shuffle_sample_in_corpus: {args.shuffle_sample_in_corpus}"
                         )
+                        desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
+                        os.makedirs(args.data_cache_path, exist_ok=True)
+                        np.save(os.path.join(args.data_cache_path, desc_hash + "_index.npy"),
+                                self.dataset_index, allow_pickle=True)
+                        np.save(os.path.join(args.data_cache_path, desc_hash + "_sample_index.npy"),
+                                self.dataset_sample_index, allow_pickle=True)
                         logger.info(
-                            f" > finished saving {self.dataset_builders[0].corpus} corpus index map files in {time.perf_counter() - start_time} seconds"
+                            f" > finished saving {corpus_name} corpus index map files"
                         )
                     except OSError:
-                        print(
-                            f"There was an error trying to create the data cache directory ({args.data_cache_path})"
-                        )
-                        print(
-                            "or a file in it. This is set with the --data-cache-path argument. Please"
-                        )
-                        print(
-                            "ensure you have write access to this directory or specify one that you do have"
-                        )
-                        print("write access to.")
-                        cache_success = False
-                    self.dataset_index = dataset_index
-                    self.dataset_sample_index = dataset_sample_index
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                if torch.distributed.get_rank() != 0 or cache_hit:
-                    # Non-rank-0 loads from files; rank 0 with cache hit also loads.
-                    # Rank 0 that just built keeps its in-memory arrays.
-                    start_time = time.perf_counter()
-                    corpus_name = self.dataset_builders[0].corpus
-                    logger.info(
-                        f"> loading {corpus_name} corpus dataset index: {index_path}"
-                    )
-                    self.dataset_index = np.load(
-                        index_path, allow_pickle=True, mmap_mode="r"
-                    )
-                    assert self.dataset_index.size == self.num_samples
-                    logger.info(
-                        f"> loading {corpus_name} corpus dataset sample index: {sample_index_path}"
-                    )
-                    self.dataset_sample_index = np.load(
-                        sample_index_path, allow_pickle=True, mmap_mode="r"
-                    )
-                    assert self.dataset_sample_index.size == self.num_samples
-                    logger.info(
-                        f"> finished loading in {time.perf_counter() - start_time} seconds"
-                    )
-            else:
+                        logger.warning(f"> failed to save {corpus_name} corpus index cache")
+
+            # Broadcast from rank 0 to all ranks
+            if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+                idx_tensor = torch.from_numpy(self.dataset_index).long()
+                sample_tensor = torch.from_numpy(self.dataset_sample_index).long()
+                torch.distributed.broadcast(idx_tensor, src=0)
+                torch.distributed.broadcast(sample_tensor, src=0)
+                if rank != 0:
+                    self.dataset_index = idx_tensor.numpy()
+                    self.dataset_sample_index = sample_tensor.numpy()
+                logger.info(f"> rank {rank}: {corpus_name} corpus indices ready (broadcast)")
+            elif not torch.distributed.is_initialized():
                 self.dataset_index, self.dataset_sample_index = _build_indices()
 
         _cache_indices()

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -208,6 +208,11 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
             self.dataset_sample_index = np.zeros(self.num_samples, dtype=np.int64)
             if args.data_cache_path:
                 desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
+                # Broadcast hash from rank 0 so all ranks use the same paths
+                if torch.distributed.is_initialized():
+                    hash_list = [desc_hash]
+                    torch.distributed.broadcast_object_list(hash_list, src=0)
+                    desc_hash = hash_list[0]
                 desc_path = os.path.join(args.data_cache_path, desc_hash + ".dsc")
                 index_path = os.path.join(
                     args.data_cache_path, desc_hash + "_index.npy"

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -1135,6 +1135,11 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
+    # Global barrier so all ranks finish building/saving before any rank loads.
+    # Without this, concurrent writes on parallel filesystems (Lustre) can
+    # corrupt files when multiple ranks write to the same paths.
+    torch.distributed.barrier()
+
     # Load mappings with retry — on parallel filesystems (Lustre), files
     # written by one rank may not be immediately visible/complete on other
     # nodes even after a barrier.

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -207,12 +207,8 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
             self.dataset_index = np.zeros(self.num_samples, dtype=np.int64)
             self.dataset_sample_index = np.zeros(self.num_samples, dtype=np.int64)
             if args.data_cache_path:
+                # desc is rank-independent (corpus name, num_samples, config flags)
                 desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
-                # Broadcast hash from rank 0 so all ranks use the same paths
-                if torch.distributed.is_initialized():
-                    hash_list = [desc_hash]
-                    torch.distributed.broadcast_object_list(hash_list, src=0)
-                    desc_hash = hash_list[0]
                 desc_path = os.path.join(args.data_cache_path, desc_hash + ".dsc")
                 index_path = os.path.join(
                     args.data_cache_path, desc_hash + "_index.npy"

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -232,15 +232,15 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                         os.makedirs(os.path.dirname(index_path), exist_ok=True)
                         with open(desc_path, "wt") as fd:
                             fd.write(desc)
-                            np.save(index_path, dataset_index, allow_pickle=True)
-                            np.save(
-                                sample_index_path,
-                                dataset_sample_index,
-                                allow_pickle=True,
-                            )
-                            logger.info(
-                                f" > finished saving {self.dataset_builders[0].corpus} corpus index map files in {time.perf_counter() - start_time} seconds"
-                            )
+                        np.save(index_path, dataset_index, allow_pickle=True)
+                        np.save(
+                            sample_index_path,
+                            dataset_sample_index,
+                            allow_pickle=True,
+                        )
+                        logger.info(
+                            f" > finished saving {self.dataset_builders[0].corpus} corpus index map files in {time.perf_counter() - start_time} seconds"
+                        )
                     except OSError:
                         print(
                             f"There was an error trying to create the data cache directory ({args.data_cache_path})"
@@ -258,24 +258,28 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
                 torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                start_time = time.perf_counter()
-                logger.info(
-                    f"> loading {self.dataset_builders[0].corpus} corpus dataset index: {index_path}"
-                )
-                self.dataset_index = np.load(
-                    index_path, allow_pickle=True, mmap_mode="r"
-                )
-                assert self.dataset_index.size == self.num_samples
-                logger.info(
-                    f"> loading {self.dataset_builders[0].corpus} corpus dataset sample index: {sample_index_path}"
-                )
-                self.dataset_sample_index = np.load(
-                    sample_index_path, allow_pickle=True, mmap_mode="r"
-                )
-                assert self.dataset_sample_index.size == self.num_samples
-                logger.info(
-                    f"> finished loading in {time.perf_counter() - start_time} seconds"
-                )
+                if torch.distributed.get_rank() != 0 or cache_hit:
+                    # Non-rank-0 loads from files; rank 0 with cache hit also loads.
+                    # Rank 0 that just built keeps its in-memory arrays.
+                    start_time = time.perf_counter()
+                    corpus_name = self.dataset_builders[0].corpus
+                    logger.info(
+                        f"> loading {corpus_name} corpus dataset index: {index_path}"
+                    )
+                    self.dataset_index = np.load(
+                        index_path, allow_pickle=True, mmap_mode="r"
+                    )
+                    assert self.dataset_index.size == self.num_samples
+                    logger.info(
+                        f"> loading {corpus_name} corpus dataset sample index: {sample_index_path}"
+                    )
+                    self.dataset_sample_index = np.load(
+                        sample_index_path, allow_pickle=True, mmap_mode="r"
+                    )
+                    assert self.dataset_sample_index.size == self.num_samples
+                    logger.info(
+                        f"> finished loading in {time.perf_counter() - start_time} seconds"
+                    )
             else:
                 self.dataset_index, self.dataset_sample_index = _build_indices()
 


### PR DESCRIPTION
Two fixes for parallel filesystem race conditions:

1. Add torch.distributed.barrier() in _build_index_mappings() between
   the index building phase and the loading phase. Without this,
   ranks that finish building their assigned datasets immediately try
   to load ALL datasets' indices, racing with ranks still writing.

2. Move np.save() calls in BlendableDataset out of the 'with open()'
   block for the description file. The saves were incorrectly nested
   inside the file context manager.