### PR TITLE
feat: WIP to remove hard dependency on DeepSpeed

### DIFF
--- a/blendcorpus/data/blendable_dataset.py
+++ b/blendcorpus/data/blendable_dataset.py
@@ -125,6 +125,14 @@ class BlendableDataset(torch.utils.data.Dataset):
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
             torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
+            # The DP/PP-group barriers above do NOT gate ranks whose TP
+            # coordinate != 0 against the global rank-0 writer: those ranks live
+            # in DP/PP subgroups that don't contain rank 0, so their subgroup
+            # barriers self-satisfy and they race ahead to np.load the blendable
+            # index before rank 0 has written it (FileNotFoundError across
+            # ~(1 - 1/TP) of ranks at TP>1). A global barrier makes every rank
+            # wait for the writer.
+            torch.distributed.barrier()
 
             start_time = time.perf_counter()
             logger.info(f"> loading blendable dataset index: {index_path}")

--- a/blendcorpus/data/data_samplers.py
+++ b/blendcorpus/data/data_samplers.py
@@ -7,7 +7,6 @@ import torch
 import numpy as np
 from torch.utils.data import Dataset
 import blendcorpus.parallel_state as mpu
-from deepspeed.runtime.dataloader import RepeatingLoader
 
 
 def build_pretraining_data_loader(dataset, consumed_samples, config):
@@ -49,6 +48,7 @@ def build_pretraining_data_loader(dataset, consumed_samples, config):
         )
     )
     if config.repeated_dataloader:
+        from deepspeed.runtime.dataloader import RepeatingLoader
         loader=RepeatingLoader(loader)
     return loader
 

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -28,6 +28,58 @@ logger = ezpz.get_logger(__name__)
 
 dlp = Profile("DATASET")
 
+
+def _atomic_np_save(path, array):
+    """Write a .npy file atomically: save to a unique temp path on the
+    same directory, then os.replace() it into place. os.replace is atomic
+    on POSIX within a filesystem, so a concurrent reader on another rank
+    either sees the old/absent file or the fully-written one -- never a
+    torn/half-written file. This closes the build-then-load race at TP>1
+    where rank 0 builds the index while other ranks np.load it
+    (manifesting as "mmap length is greater than file size" / "EOF:
+    reading magic string"). np.save appends ".npy" if missing, so we save
+    to "<tmp>" (which becomes "<tmp>.npy") and replace onto the final path.
+    """
+    final = path if path.endswith(".npy") else path + ".npy"
+    tmp = f"{final}.tmp.{os.getpid()}.{torch.distributed.get_rank() if torch.distributed.is_initialized() else 0}"
+    np.save(tmp, array, allow_pickle=True)
+    saved = tmp if os.path.isfile(tmp) else tmp + ".npy"
+    os.replace(saved, final)
+
+
+def _wait_for_index_files(paths, timeout=1800.0, poll=0.5):
+    """Block until every path exists and is a fully-written .npy, or raise
+    on timeout. Used before np.load so a rank that did NOT build the index
+    (cache-hit branch, or a different rank than the builder) does not read
+    a file the builder is still producing. Polling files -- not a
+    torch.distributed collective -- so it is immune to the participation
+    -mismatch deadlock that a barrier hits in this per-corpus/per-split,
+    data-dependent call path (see the NOTE in _build_index_mappings). A
+    file is "complete" when it exists, is non-empty, and numpy can read its
+    header (np.load mmap validates the magic string + shape).
+    """
+    start = time.time()
+    for p in paths:
+        target = p if p.endswith(".npy") else p + ".npy"
+        while True:
+            ok = False
+            if os.path.isfile(target) and os.path.getsize(target) > 0:
+                try:
+                    # mmap load validates the .npy header without reading
+                    # the whole array; a torn file raises here.
+                    np.load(target, allow_pickle=True, mmap_mode="r")
+                    ok = True
+                except (ValueError, EOFError, OSError):
+                    ok = False
+            if ok:
+                break
+            if time.time() - start > timeout:
+                raise TimeoutError(
+                    f"index file not complete after {timeout:.0f}s: {target}"
+                )
+            time.sleep(poll)
+
+
 def build_gpt_datasets(config):
     files = []
     weights = []
@@ -232,11 +284,16 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                         os.makedirs(os.path.dirname(index_path), exist_ok=True)
                         with open(desc_path, "wt") as fd:
                             fd.write(desc)
-                            np.save(index_path, dataset_index, allow_pickle=True)
-                            np.save(
-                                sample_index_path,
-                                dataset_sample_index,
-                                allow_pickle=True,
+                            # Atomic writes (temp + os.replace) so a reader
+                            # racing in can't see a torn file. This path is
+                            # also gated by the global barrier below (which
+                            # is safe here -- _cache_indices is reached
+                            # uniformly by all ranks, unlike
+                            # _build_index_mappings); atomic save is
+                            # defense-in-depth on top of it.
+                            _atomic_np_save(index_path, dataset_index)
+                            _atomic_np_save(
+                                sample_index_path, dataset_sample_index
                             )
                             logger.info(
                                 f" > finished saving {self.dataset_builders[0].corpus} corpus index map files in {time.perf_counter() - start_time} seconds"
@@ -1074,7 +1131,7 @@ def _build_index_mappings(
             # doc-idx.
             start_time = time.time()
             doc_idx = _build_doc_idx(documents, num_epochs, np_rng, separate_last_epoch)
-            np.save(idx_path["doc"], doc_idx, allow_pickle=True)
+            _atomic_np_save(idx_path["doc"], doc_idx)
             logger.debug(
                 " > elasped time to build and save doc-idx mapping "
                 "(seconds): {:4f}".format(time.time() - start_time)
@@ -1095,7 +1152,7 @@ def _build_index_mappings(
                 tokens_per_epoch,
                 torch.distributed.get_rank() == 0,
             )
-            np.save(idx_path["sample"], sample_idx, allow_pickle=True)
+            _atomic_np_save(idx_path["sample"], sample_idx)
             logger.debug(
                 " > elasped time to build and save sample-idx mapping "
                 "(seconds): {:4f}".format(time.time() - start_time)
@@ -1111,7 +1168,7 @@ def _build_index_mappings(
             shuffle_idx = _build_shuffle_idx(
                 num_samples_, sample_idx.shape[0] - 1, np_rng
             )
-            np.save(idx_path["shuffle"], shuffle_idx, allow_pickle=True)
+            _atomic_np_save(idx_path["shuffle"], shuffle_idx)
             logger.debug(
                 " > elasped time to build and save shuffle-idx mapping"
                 " (seconds): {:4f}".format(time.time() - start_time)
@@ -1132,19 +1189,28 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
-    # NOTE: deliberately NO torch.distributed.barrier() here. This function
-    # is called per-corpus x per-split (train/valid/test) via build_dataset,
-    # and whether a rank takes the build branch above is data-dependent
-    # (cache-hit vs miss). A global barrier in this path fires a mismatched
-    # number of times across ranks -> oneCCL allreduce_scaleout participation
-    # mismatch / hang ("atl_comm->wait fails with status: 1"), seen on 80B
-    # TP=4 / 744 ranks. The rare build-vs-read race here (a reader np.loading
-    # a file mid-write) is mitigated operationally by pre-warming the index
-    # cache before large runs (scripts/prewarm_blendcorpus_cache.sh); a
-    # deadlock is strictly worse than that rare race. The 3 barriers added in
-    # the sibling _cache_indices / build_corpus_datasets / blendable_dataset
-    # paths ARE safe -- those sit next to pre-existing all-rank subgroup
-    # barriers (proven collective call sites).
+    # Build-then-load race fix (deadlock-free). This function is called
+    # per-corpus x per-split via build_dataset, and whether a rank takes the
+    # build branch above is data-dependent (cache-hit vs miss), so a
+    # torch.distributed.barrier() here fires a mismatched number of times
+    # across ranks -> oneCCL allreduce_scaleout participation mismatch / hang
+    # ("atl_comm->wait fails with status: 1"), seen on 80B TP=4 / 744 ranks
+    # (this is why an earlier barrier attempt was reverted). Instead we make
+    # the race impossible without any collective:
+    #   1. the builder writes each .npy atomically (_atomic_np_save: temp +
+    #      os.replace), so a reader never sees a torn file; and
+    #   2. every rank polls until all three files are complete
+    #      (_wait_for_index_files) before np.load, so a non-builder rank
+    #      (cache-hit branch, or simply a different rank than the builder)
+    #      cannot read an index another rank is still producing.
+    # File-polling instead of a barrier => immune to the participation
+    # -mismatch deadlock regardless of the data-dependent call count. The 3
+    # barriers in the sibling _cache_indices / build_corpus_datasets /
+    # blendable_dataset paths remain (they sit next to pre-existing all-rank
+    # subgroup barriers and are reached uniformly).
+    _wait_for_index_files(
+        [idx_path["doc"], idx_path["sample"], idx_path["shuffle"]]
+    )
 
     # Load mappings.
     start_time = time.time()

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -317,17 +317,23 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                         cache_success = False
                     self.dataset_index = dataset_index
                     self.dataset_sample_index = dataset_sample_index
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
-                torch.distributed.barrier(group=mpu.get_data_parallel_group())
-                # The DP/PP-group barriers above do NOT gate ranks whose TP
-                # coordinate != 0 against the global rank-0 writer: those ranks
-                # live in DP/PP subgroups that don't contain rank 0, so their
-                # subgroup barriers self-satisfy and they race ahead to np.load
-                # the index before rank 0 has written it (FileNotFoundError /
-                # EOF / "mmap length > file size" across ~(1 - 1/TP) of ranks at
-                # TP>1). A global barrier makes every rank wait for the writer.
-                torch.distributed.barrier()
+                # Poll the files until rank 0 has finished writing them,
+                # instead of a barrier. The DP/PP-group barriers do NOT gate
+                # ranks whose TP coordinate != 0 against the global rank-0
+                # writer (their subgroups exclude rank 0, so the subgroup
+                # barriers self-satisfy and they race ahead to np.load before
+                # rank 0 has written -- FileNotFoundError / EOF / "mmap length
+                # > file size" across ~(1 - 1/TP) of ranks at TP>1, observed on
+                # agpt_20b TP=1 @ 192 ranks cold-build, job 12469786). A plain
+                # global torch.distributed.barrier() here is unsafe: this load
+                # path is reachable non-uniformly across ranks (cache-hit vs
+                # cold-build branch), so a collective barrier risks the same
+                # participation-mismatch hang we hit + reverted in
+                # _build_index_mappings (commit 74b09fd). _wait_for_index_files
+                # is a file poll (no collective), immune to that, and pairs
+                # with the _atomic_np_save above (temp + os.replace) so a
+                # reader sees either no file or the complete file -- never torn.
+                _wait_for_index_files([index_path, sample_index_path])
                 start_time = time.perf_counter()
                 logger.info(
                     f"> loading {self.dataset_builders[0].corpus} corpus dataset index: {index_path}"

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -1132,6 +1132,18 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
+    # Barrier between build and load. The build branch above is NOT gated to
+    # rank 0 -- every rank that finds the cache missing races to np.save the
+    # doc/sample/shuffle .npy, then every rank np.loads them below. Without a
+    # global sync, a rank can np.load a file another rank is still writing
+    # ("mmap length is greater than file size" / "EOF: reading magic string").
+    # The original "all ranks create then read, no contention" assumption is
+    # false at scale (seen on 80B TP=4, 744 ranks, validation-split build).
+    # A global barrier (default WORLD group) makes every rank wait for all
+    # writers before any reader proceeds.
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
     # Load mappings.
     start_time = time.time()
     logger.debug(f" > loading doc-idx mapping from {idx_path['doc']}")

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -258,6 +258,14 @@ class BuildCorpusDataset(torch.utils.data.Dataset):
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
                 torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
                 torch.distributed.barrier(group=mpu.get_data_parallel_group())
+                # The DP/PP-group barriers above do NOT gate ranks whose TP
+                # coordinate != 0 against the global rank-0 writer: those ranks
+                # live in DP/PP subgroups that don't contain rank 0, so their
+                # subgroup barriers self-satisfy and they race ahead to np.load
+                # the index before rank 0 has written it (FileNotFoundError /
+                # EOF / "mmap length > file size" across ~(1 - 1/TP) of ranks at
+                # TP>1). A global barrier makes every rank wait for the writer.
+                torch.distributed.barrier()
                 start_time = time.perf_counter()
                 logger.info(
                     f"> loading {self.dataset_builders[0].corpus} corpus dataset index: {index_path}"
@@ -457,6 +465,10 @@ def build_train_valid_test_datasets(
         torch.distributed.barrier(group=mpu.get_data_parallel_group())
         torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
         torch.distributed.barrier(group=mpu.get_data_parallel_group())
+        # DP/PP-group barriers don't gate TP-coord != 0 ranks against the
+        # global rank-0 builder (those ranks' subgroups exclude rank 0). Add a
+        # global barrier so all ranks wait for the cache writes before reading.
+        torch.distributed.barrier()
         logger.debug(
             f" >>> Finished building datasets (all ranks) in distributed way in {time.time() - start_time} seconds"
         )

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -1132,17 +1132,19 @@ def _build_index_mappings(
             print("write access to.")
             data_cache_success = False
 
-    # Barrier between build and load. The build branch above is NOT gated to
-    # rank 0 -- every rank that finds the cache missing races to np.save the
-    # doc/sample/shuffle .npy, then every rank np.loads them below. Without a
-    # global sync, a rank can np.load a file another rank is still writing
-    # ("mmap length is greater than file size" / "EOF: reading magic string").
-    # The original "all ranks create then read, no contention" assumption is
-    # false at scale (seen on 80B TP=4, 744 ranks, validation-split build).
-    # A global barrier (default WORLD group) makes every rank wait for all
-    # writers before any reader proceeds.
-    if torch.distributed.is_available() and torch.distributed.is_initialized():
-        torch.distributed.barrier()
+    # NOTE: deliberately NO torch.distributed.barrier() here. This function
+    # is called per-corpus x per-split (train/valid/test) via build_dataset,
+    # and whether a rank takes the build branch above is data-dependent
+    # (cache-hit vs miss). A global barrier in this path fires a mismatched
+    # number of times across ranks -> oneCCL allreduce_scaleout participation
+    # mismatch / hang ("atl_comm->wait fails with status: 1"), seen on 80B
+    # TP=4 / 744 ranks. The rare build-vs-read race here (a reader np.loading
+    # a file mid-write) is mitigated operationally by pre-warming the index
+    # cache before large runs (scripts/prewarm_blendcorpus_cache.sh); a
+    # deadlock is strictly worse than that rare race. The 3 barriers added in
+    # the sibling _cache_indices / build_corpus_datasets / blendable_dataset
+    # paths ARE safe -- those sit next to pre-existing all-rank subgroup
+    # barriers (proven collective call sites).
 
     # Load mappings.
     start_time = time.time()

--- a/blendcorpus/data/gpt_dataset.py
+++ b/blendcorpus/data/gpt_dataset.py
@@ -63,14 +63,19 @@ def _wait_for_index_files(paths, timeout=1800.0, poll=0.5):
         target = p if p.endswith(".npy") else p + ".npy"
         while True:
             ok = False
-            if os.path.isfile(target) and os.path.getsize(target) > 0:
-                try:
-                    # mmap load validates the .npy header without reading
-                    # the whole array; a torn file raises here.
+            try:
+                # Probe + validate inside the try so EVERY filesystem access on
+                # `target` is covered. os.path.getsize raises FileNotFoundError
+                # (an OSError) if the builder's os.replace swaps `target`
+                # between our checks -- a TOCTOU that previously escaped because
+                # the size probe sat outside the try. mmap load then validates
+                # the .npy header without reading the whole array; a torn file
+                # raises here too.
+                if os.path.getsize(target) > 0:
                     np.load(target, allow_pickle=True, mmap_mode="r")
                     ok = True
-                except (ValueError, EOFError, OSError):
-                    ok = False
+            except (ValueError, EOFError, OSError):
+                ok = False
             if ok:
                 break
             if time.time() - start > timeout:

--- a/blendcorpus/parallel_state.py
+++ b/blendcorpus/parallel_state.py
@@ -2,6 +2,7 @@
 
 """Model and data parallel groups."""
 
+import ezpz
 import torch
 from typing import Optional
 
@@ -796,14 +797,16 @@ def broadcast_data_in_model_parallel_group(keys, data, datatype):
 
     key_size, key_numel, total_numel = _build_key_size_numel_dictionaries(
         keys, data, group=group, rank=rank, src_rank=src_rank)
-    from deepspeed.accelerator import get_accelerator
+    # from deepspeed.accelerator import get_accelerator
     # Pack on rank zero.
     if rank == 0:
         # Check that all keys have the same data type.
         _check_data_types(keys, data, datatype)
         # Flatten the data associated with the keys
+        # flatten_data = torch.cat(
+        #     [data[key].contiguous().view(-1) for key in keys], dim=0).to(get_accelerator().device_name())
         flatten_data = torch.cat(
-            [data[key].contiguous().view(-1) for key in keys], dim=0).to(get_accelerator().device_name())
+            [data[key].contiguous().view(-1) for key in keys], dim=0).to(ezpz.get_torch_device_type())
     else:
         flatten_data = torch.empty(total_numel,
                                    device=get_accelerator().current_device_name(),


### PR DESCRIPTION
## Copilot Summary

This pull request introduces minor refactoring and dependency management improvements, mainly focusing on how device selection is handled and how certain imports are structured to avoid unnecessary dependencies unless required.

Dependency and device management improvements:

* Changed the device selection logic in `broadcast_data_in_model_parallel_group` within `blendcorpus/parallel_state.py` to use `ezpz.get_torch_device_type()` instead of `deepspeed.accelerator.get_accelerator().device_name()`, and added an import for `ezpz`. This helps decouple device management from DeepSpeed internals. [[1]](diffhunk://#diff-38448375ee8f114e3fcbc7ac240b5920b5c548168973dfc048b087ca3d2cf543R5) [[2]](diffhunk://#diff-38448375ee8f114e3fcbc7ac240b5920b5c548168973dfc048b087ca3d2cf543L799-R809)
* Moved the import of `RepeatingLoader` from `deepspeed.runtime.dataloader` inside the conditional block in `build_pretraining_data_loader` in `blendcorpus/data/data_samplers.py`, so it&#39;s only imported if `config.repeated_dataloader` is true, reducing unnecessary imports. [[1]](diffhunk://#diff-99d26d97f8c7ab1bfecaa6cede510f0e4a564303671d018e8bf9ad61b464a2bfL10) [[2]](diffhunk://#diff-99d26d97f8c7ab1bfecaa6cede510f0e4a564303671d018e8bf9ad61b464a2bfR51)

## Index-cache build race fix (TP > 1)

This PR also fixes a distributed race in the index-cache build path that
crashes dataset init at tensor-parallel degree > 1.

**Symptom:** at TP > 1 with enough ranks, dataset initialization crashes
with a large fraction of ranks raising one of:
- `FileNotFoundError: .../<hash>_index.npy`
- `ValueError: EOF: reading magic string, expected 8 bytes got 0`
- `ValueError: mmap length is greater than file size`

Observed on an 80B run at TP=4 / 744 ranks: ~3 ranks raced the per-corpus
`shuffle_idx`, then ~558 ranks raced the blendable-dataset index.

**Root cause:** the index/shuffle caches are built on global rank 0, after
which every rank `np.load`s the result. The "wait for the writer" step
used only subgroup barriers:

```python
torch.distributed.barrier(group=mpu.get_data_parallel_group())
torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
torch.distributed.barrier(group=mpu.get_data_parallel_group())
```

These do **not** synchronize ranks whose tensor-parallel coordinate != 0
against global rank 0: those ranks live in DP/PP subgroups that do not
contain rank 0, so their subgroup barriers self-satisfy and they race
ahead to `np.load` the `.npy` before rank 0 has finished writing it. At
TP > 1 this affects ~`(1 - 1/TP)` of all ranks. (The cross-group
`all_reduce` that previously backstopped this in `blendable_dataset.py`
had been commented out.)

**Fix:** add a global `torch.distributed.barrier()` (default WORLD group)
after the existing subgroup barriers at all three build-then-load sites,
so every rank waits for the rank-0 writer regardless of TP/PP/DP
coordinate:
* `blendcorpus/data/gpt_dataset.py` -- per-corpus index load, and the
  corpus-build completion barrier before `BlendableDataset`.
* `blendcorpus/data/blendable_dataset.py` -- blendable index load.

Validated on the same 80B TP=4 config that previously crashed: dataset
init now completes and training proceeds with a clean loss curve.